### PR TITLE
Hive & Base path update

### DIFF
--- a/hive/create_revdocs_table.hql
+++ b/hive/create_revdocs_table.hql
@@ -37,7 +37,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS ${revdocs_table} (
     model STRING,
     format STRING
 )
-ROW FORMAT SERDE 'org.apache.hcatalog.data.JsonSerDe'
+ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe'
 STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
 OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
 LOCATION '${data_path}'

--- a/hive/load_metadata_from_revdocs.hql
+++ b/hive/load_metadata_from_revdocs.hql
@@ -17,7 +17,7 @@
 --
 -- Usage
 --     hive -f load_metadata_from_revdocs.hql          \
---          -d hcatalog_path=/opt/hive/hcatalog/share/hcatalog/hive-hcatalog-core-0.13.1.jar \
+--          -d hcatalog_path=/opt/hive/hcatalog/share/hcatalog/hive-hcatalog-core-1.2.0.jar \
 --          -d metastore_path=/opt/hive/lib/hive-metastore-1.2.0.jar \
 --          -d queue=default                           \
 --          -d reducers=64                             \
@@ -30,7 +30,7 @@ ADD JAR ${hcatalog_path};
 ADD JAR ${metastore_path};
 
 
-set mapred.job.queue.name    = ${queue};
+SET mapred.job.queue.name    = ${queue};
 SET mapreduce.job.reduces    = ${reducers};
 SET parquet.compression      = ${compression};
 
@@ -43,7 +43,10 @@ SELECT
     page_title,
     page_namespace,
     page_redirect,
-    page_restrictions,
+    CASE WHEN size(page_restrictions) = 0
+        THEN NULL
+        ELSE page_restrictions
+    END AS page_restrictions,
     user_id,
     user_text,
     minor,
@@ -63,7 +66,10 @@ GROUP BY
     page_title,
     page_namespace,
     page_redirect,
-    page_restrictions,
+    CASE WHEN size(page_restrictions) = 0
+        THEN NULL
+        ELSE page_restrictions
+    END,
     user_id,
     user_text,
     minor,

--- a/hive/load_metadata_from_revdocs.hql
+++ b/hive/load_metadata_from_revdocs.hql
@@ -18,6 +18,7 @@
 -- Usage
 --     hive -f load_metadata_from_revdocs.hql          \
 --          -d hcatalog_path=/opt/hive/hcatalog/share/hcatalog/hive-hcatalog-core-0.13.1.jar \
+--          -d metastore_path=/opt/hive/lib/hive-metastore-1.2.0.jar \
 --          -d queue=default                           \
 --          -d reducers=64                             \
 --          -d compression=SNAPPY                      \
@@ -26,6 +27,8 @@
 
 
 ADD JAR ${hcatalog_path};
+ADD JAR ${metastore_path};
+
 
 set mapred.job.queue.name    = ${queue};
 SET mapreduce.job.reduces    = ${reducers};

--- a/python/wiki_etl.py
+++ b/python/wiki_etl.py
@@ -28,7 +28,7 @@ Options:
                                from fulltext one
 
     --base-path=<path>       Base path where to store the files
-                               [default: /wikimedia_data]
+                               [default: /wmf/data]
 
     --name-node=<host>       Host of the cluster name-node to use
                                [default: http://nn-ia.s3s.altiscale.com:50070]

--- a/python/wiki_etl.py
+++ b/python/wiki_etl.py
@@ -78,7 +78,9 @@ Options:
     --hive-database=<db>     Hive database against which to run the script
                                [default: wmf_dumps]
     --hive-hcatalog=<path>   Path to the hive-hcatalog-core jar file
-                               [default: /opt/hive/hcatalog/share/hcatalog/hive-hcatalog-core-0.13.1.jar]
+                               [default: /opt/hive/hcatalog/share/hcatalog/hive-hcatalog-core-1.2.0.jar]
+    --hive-metastore=<path>   Path to the hive-metastore jar file
+                               [default: /opt/hive/lib/hive-metastore-1.2.0.jar]
     --hive-metadata-red=<n>  Number of reducers used to extract metadata from
                                json data (defines the number of output files)
                                [default: 64]
@@ -113,6 +115,7 @@ HQL_SCRIPT_METADATA_TABLE = "../hive/create_metadata_table.hql"
 HQL_SCRIPT_METADATA_LOAD = "../hive/load_metadata_from_revdocs.hql"
 
 HQL_PARAM_HCATALOG_PATH = "hcatalog_path"
+HQL_PARAM_METASTORE_PATH = "metastore_path"
 HQL_PARAM_FULLTEXT_TABLE = "revdocs_table"
 HQL_PARAM_METADATA_TABLE = "metadata_table"
 HQL_PARAM_DATA_PATH = "data_path"
@@ -155,6 +158,7 @@ class WikiDumpEtl(object):
                  hive_port,
                  hive_database,
                  hive_hcatalog,
+                 hive_metastore,
                  hive_metadata_reducers,
                  hive_metadata_compression,
                  force,
@@ -192,6 +196,7 @@ class WikiDumpEtl(object):
         self.hive_port = hive_port
         self.hive_database = hive_database
         self.hive_hcatalog = hive_hcatalog
+        self.hive_metastore = hive_metastore
         self.hive_metadata_reducers = hive_metadata_reducers
         self.hive_metadata_compression = hive_metadata_compression
         self.force = force
@@ -300,6 +305,7 @@ class WikiDumpEtl(object):
         hql_path = self._hive_path(HQL_SCRIPT_METADATA_LOAD)
         hql_params = [
             self._hive_param(HQL_PARAM_HCATALOG_PATH, self.hive_hcatalog),
+            self._hive_param(HQL_PARAM_METASTORE_PATH, self.hive_metastore),
             self._hive_param(HQL_PARAM_QUEUE, self.queue),
             self._hive_param(HQL_PARAM_REDUCERS, self.hive_metadata_reducers),
             self._hive_param(HQL_PARAM_COMPRESSION,
@@ -366,6 +372,7 @@ def main(args):
     hive_port = args["--hive-port"]
     hive_database = args["--hive-database"]
     hive_hcatalog = args["--hive-hcatalog"]
+    hive_metastore = args["--hive-metastore"]
     hive_metadata_reducers = args["--hive-metadata-red"]
     hive_metadata_compression = args["--hive-metadata-cpr"]
     force = args["--force"]
@@ -402,6 +409,7 @@ def main(args):
                       hive_port,
                       hive_database,
                       hive_hcatalog,
+                      hive_metastore,
                       hive_metadata_reducers,
                       hive_metadata_compression,
                       force,


### PR DESCRIPTION
Changes are:
- change default base path to /wmf/data
- Upgrade default hive catalog jar to 1.2.0
- Update JsonSerde package path (changed in hcatalog)
- Add metastore jar when using fulltext table (now needed by JsonSerde)
- Modify load script to use null instead of empty array to mitigate hive/ parquet bug.
